### PR TITLE
Add missing Functor instance. Made compatible with GHC 8.0.2. 

### DIFF
--- a/mrm.cabal
+++ b/mrm.cabal
@@ -24,6 +24,7 @@ category:            Data
 build-type:          Simple
 extra-source-files:  README.md
 cabal-version:       >=1.10
+tested-with:         GHC==8.0.2, GHC==7.10.3, GHC==7.8.4
 
 source-repository head
   type:                 git
@@ -31,7 +32,7 @@ source-repository head
 
 library
   hs-source-dirs:      src
-  build-depends:       base >=4.7 && <4.8
+  build-depends:       base >=4.7 && <5.0
   other-extensions:    GADTs
   exposed-modules:     Data.Match,
                        Data.ConstrainedList,

--- a/src/Data/Match/Effects.hs
+++ b/src/Data/Match/Effects.hs
@@ -30,10 +30,14 @@ transFree = Free ^<< transAlgWith (subSub srep) <<^ getFix
 transFreeSym :: (fs <: gs) => Algebras (Pure a ': fs) (Free gs a)
 transFreeSym = Free ^<< transAlgWith (SCons Here (subSub srep)) <<^ getFix
 
+instance (fs <: fs) => Functor (Free fs) where
+    fmap f = fold ((\(Pure x) -> Free (inn (Pure (f x)))) ::: transFree) . getFix
+
 instance (fs <: fs) => Monad (Free fs) where
     return         = Free . inn . Pure
     (Free p) >>= f = fold ((\(Pure x) -> f x) :::
                            transFree) p
+
 instance (Monad (Free fs), Functor (Free fs)) => Applicative (Free fs) where
     pure = return
     (<*>) = ap

--- a/src/Data/Match/Membership.hs
+++ b/src/Data/Match/Membership.hs
@@ -1,12 +1,16 @@
 {-# LANGUAGE
-    GADTs
+    CPP
+  , GADTs
   , KindSignatures
   , DataKinds
   , TypeOperators
   , MultiParamTypeClasses
   , FlexibleInstances
-  , OverlappingInstances
   #-}
+
+#if __GLASGOW_HASKELL__ < 710
+{-# LANGUAGE OverlappingInstances #-}
+#endif
 
 module Data.Match.Membership
   ( Elem(..)
@@ -24,5 +28,9 @@ class Mem f fs where
 instance Mem f (f ': fs) where
     witness = Here
 
-instance (Mem f fs) => Mem f (g ': fs) where
+instance
+#if __GLASGOW_HASKELL__ >= 710
+  {-# OVERLAPPABLE #-}
+#endif
+  (Mem f fs) => Mem f (g ': fs) where
     witness = There witness

--- a/src/Data/Match/Monadic.hs
+++ b/src/Data/Match/Monadic.hs
@@ -7,7 +7,7 @@ module Data.Match.Monadic where
 
 import Data.Match (Algebras, Match(..), fold, transAlg)
 import Data.Match.Fix (Fix())
-import Data.Match.Subset ((<:)(..))
+import Data.Match.Subset (type (<:)(..))
 import Data.ConstrainedList (TraversableList(..), Traversables(trep))
 
 import Prelude hiding (sequence)

--- a/src/Data/Match/Subset.hs
+++ b/src/Data/Match/Subset.hs
@@ -5,7 +5,6 @@
   , TypeOperators
   , MultiParamTypeClasses
   , FlexibleInstances
-  , OverlappingInstances
   #-}
 
 module Data.Match.Subset where


### PR DESCRIPTION
I successfully built this with GHC 8.0.2, 7.10.3, and 7.8.4. No compiler warnings.

Regarding the missing `Functor` instance: Why was it missing? I can't figure it out :)